### PR TITLE
Channel bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Receive messages on channel `my-channel`:
 river.subscribe("my-channel");
 ```
 
+Returns a `Channel` object, to which events can be bound.
+
 ### Unsubscribe
 
 Stop receiving messages on channel `my-channel`:
@@ -58,17 +60,15 @@ river.unsubscribe("my-channel");
 ### Receiving messages
 
 ```javascript
-river.on("eventName", (payload) => {
-  // do something
-})
+// subscribe first
+const myChannel = river.subscribe("my-channel");
 
-// payload example
-{
-  channel: "my-channel",
-  data: data
-}
+// bind event to channel
+myChannel.bind("eventName", (data) => {
+  // do something
+});
 ```
 
-The callback function given to the `.on` method (as the second argument) is executed every time a message is received with a matching `eventName`, on a channel to which the client is subscribed.
+The callback function given to the `.bind` method (as the second argument) is executed every time a message is received on that channel with a matching `eventName`.
 
 `"my-channel"`, `"eventName"`, and `data` correspond to the `channel`, `eventName`, and `data` given when the event is published to River. Please see the [`http-node`](https://github.com/river-live/http-node) repo for more information.

--- a/lib/river.js
+++ b/lib/river.js
@@ -59,8 +59,8 @@ class Channel {
     this.channel = channel;
   }
 
-  bind(channelName, cb) {
-    this.socket.on(channelName, (payload) => {
+  bind(eventName, cb) {
+    this.socket.on(eventName, (payload) => {
       if (payload.channel == this.channel) {
         cb(payload.data);
       }

--- a/lib/river.js
+++ b/lib/river.js
@@ -29,6 +29,7 @@ class River {
   subscribe(channel) {
     if (this.auth) {
       this.socket.emit("subscribe", channel);
+      return new Channel(this.socket, channel);
     } else {
       // not authenticated yet, wait until auth is true before sending!
       const intervalId = setInterval(() => {
@@ -51,6 +52,21 @@ class River {
   on(eventName, callback) {
     this.socket.on(eventName, (data) => {
       callback(data);
+    });
+  }
+}
+
+class Channel {
+  constructor(socket, channel) {
+    this.socket = socket;
+    this.channel = channel;
+  }
+
+  bind(channelName, cb) {
+    this.socket.on(channelName, (data) => {
+      if (data.channel == this.channel) {
+        cb(data);
+      }
     });
   }
 }

--- a/lib/river.js
+++ b/lib/river.js
@@ -27,18 +27,15 @@ class River {
   }
 
   subscribe(channel) {
-    if (this.auth) {
-      this.socket.emit("subscribe", channel);
-      return new Channel(this.socket, channel);
-    } else {
-      // not authenticated yet, wait until auth is true before sending!
-      const intervalId = setInterval(() => {
-        if (this.auth) {
-          clearInterval(intervalId);
-          this.socket.emit("subscribe", channel);
-        }
-      }, 50);
-    }
+    // not authenticated yet, wait until auth is true before sending!
+    const intervalId = setInterval(() => {
+      if (this.auth) {
+        clearInterval(intervalId);
+        this.socket.emit("subscribe", channel);
+      }
+    }, 50);
+
+    return new Channel(this.socket, channel);
   }
 
   unsubscribe(channel) {
@@ -63,9 +60,9 @@ class Channel {
   }
 
   bind(channelName, cb) {
-    this.socket.on(channelName, (data) => {
-      if (data.channel == this.channel) {
-        cb(data);
+    this.socket.on(channelName, (payload) => {
+      if (payload.channel == this.channel) {
+        cb(payload.data);
       }
     });
   }


### PR DESCRIPTION
I added a `Channel` class. A `Channel` object is returned after subscribing, which is used to bind events. I updated the readme to show usage.

Adding this eliminates the need for the developer to check the channel that the incoming message is on. 

This change shouldn't break our demo apps, as the `on` method is still available in the `River` class, but might be good to test. 

I didn't test it (yet) with River deployed on AWS, just with docker containers running locally. I used the server from our master branch in the `deploy` repo, so it should work.